### PR TITLE
Add installation steps to readme for different OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proof of concept Shiny container by [Appsilon](https://appsilon.com/) based on [
 
 ## Installation and Requirements
 
-Refer the [installation_guide.md](installation_guide.md) for installation steps
+Refer the [installation_guide.md](installation_guide.md) for installation steps for [Windows](installation_guide.md#windows), [Mac OSX](installation_guide.md#macos) and [Ubuntu](installation_guide.md#ubuntu 
 
 ## Steps to run the Pilot-4 app
 

--- a/README.md
+++ b/README.md
@@ -6,76 +6,7 @@ Proof of concept Shiny container by [Appsilon](https://appsilon.com/) based on [
 
 ## Installation and Requirements
 
-### Windows
-
-1. Install [Podman Desktop](https://podman-desktop.io/downloads/Windows)
-2. Install [WSL 2 from the Microsoft Store](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R)
-3. Install python and pip if not already present. Then install the `podman-compose` package using the following command:
-
-   ```
-   pip install podman-compose
-   ```
-
-4. Open the `Control panel` -> Open `Turn Windows feature on or off` -> Make sure that the `Windows Hypervisor Platform` is checked. Restart the computer if you just checked it.
-5. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
-
-   Alternatively, this can be done by running the following command
-
-   ```
-   podman machine init
-   ```
-
-### Ubuntu
-
-1. Install [Podman Desktop](https://podman-desktop.io/downloads/Linux)
-
-2. Install `podman-compose` using apt or PyPl
-   ```
-   sudo apt install qemu-system podman podman-compose -y
-   ```
-   or
-   ```
-   pip install podman-compose
-   ```
-3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
-
-   Alternatively, this can be done by running the following command
-
-   ```
-   podman machine init
-   ```
-
-### MacOS
-
-1. Install [Podman Desktop](https://podman-desktop.io/downloads/MacOS)
-
-   Alternatively, you can install it using brew
-
-   ```
-   brew install podman
-   ```
-
-2. Install `podman-compose` using homebrew or PyPl
-   ```
-   brew install podman-compose
-   ```
-   or
-   ```
-   pip install podman-compose
-   ```
-3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
-
-   Alternatively, this can be done by running the following command
-
-   ```
-   podman machine init
-   ```
-
-#### Private images
-
-If you plan to use a private image you need to configure registries so Podman has access to pulling them. You can do this in the `Settings` -> `Registries`
-
-However, this repository does not use any private image so this step is not required.
+Refer the [installation_guide.md](installation_guide.md) for installation steps
 
 ## Steps to run the Pilot-4 app
 
@@ -95,7 +26,6 @@ There are 2 methods to run the container. Using `podman` or `podman-compose`
 After running the container, the Pilot-4 application can be accessed in the browser at `http://localhost:8787`.
 
 ```bash
-podman machine init
 podman build . --tag experimental-fda-submission-4-podman
 podman pod create --publish 8787:8787 --name pilot-pod
 podman run -dt --pod pilot-pod experimental-fda-submission-4-podman:latest
@@ -108,6 +38,10 @@ After running the container, the Pilot-4 application can be accessed in the brow
 ```bash
 podman-compose up -d --pull
 ```
+
+## Screenshot of the Pilot running
+
+![Screen shot of the teal application running in the container](screenshot.png)
 
 ### Appendix
 
@@ -167,7 +101,3 @@ ARG IMAGE_ORG=rocker-org
 # build the image using podman-compose by running:
 # podman-compose build --pull pilot-4-podman
 ```
-
-## Screenshot of the Pilot running
-
-![Screen shot of the teal application running in the container](screenshot.png)

--- a/README.md
+++ b/README.md
@@ -4,44 +4,114 @@
 
 Proof of concept Shiny container by [Appsilon](https://appsilon.com/) based on [Pilot 2](https://github.com/RConsortium/submissions-pilot2/) from the RConsortium.
 
-## Requirements
+## Installation and Requirements
 
-[Install Podman](https://podman.io/docs/installation) locally _(in Ubuntu it can be installed via `sudo apt install qemu-system podman podman-compose -y.`)_
+### Windows
 
-Clone the repository and initialize the git modules _(`submission-pilot2` with the default Golem-based Application and `rhino/pilot2-modified` with Rhino-based application)_.
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/Windows)
+2. Install [WSL 2 from the Microsoft Store](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R)
+3. Install python and pip if not already present. Then install the `podman-compose` package using the following command:
+
+   ```
+   pip install podman-compose
+   ```
+
+4. Open the `Control panel` -> Open `Turn Windows feature on or off` -> Make sure that the `Windows Hypervisor Platform` is checked. Restart the computer if you just checked it.
+5. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+### Ubuntu
+
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/Linux)
+
+2. Install `podman-compose` using apt or PyPl
+   ```
+   sudo apt install qemu-system podman podman-compose -y
+   ```
+   or
+   ```
+   pip install podman-compose
+   ```
+3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+### MacOS
+
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/MacOS)
+
+   Alternatively, you can install it using brew
+
+   ```
+   brew install podman
+   ```
+
+2. Install `podman-compose` using homebrew or PyPl
+   ```
+   brew install podman-compose
+   ```
+   or
+   ```
+   pip install podman-compose
+   ```
+3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+#### Private images
+
+If you plan to use a private image you need to configure registries so Podman has access to pulling them. You can do this in the `Settings` -> `Registries`
+
+However, this repository does not use any private image so this step is not required.
+
+## Steps to run the Pilot-4 app
+
+### Step 1 - Download / clone the repository
 
 ```
-$ git clone --recurse-submodules https://github.com/Appsilon/experimental-fda-submission-4-podman
-$ cd experimental-fda-submission-4-podman
+git clone --recurse-submodules https://github.com/Appsilon/experimental-fda-submission-4-podman
+cd experimental-fda-submission-4-podman
 ```
 
-## Run the container locally
+### Step 2 - Run the container locally
 
-There are 2 methods to run the container:
+There are 2 methods to run the container. Using `podman` or `podman-compose`
 
-1. Creating and running a container via `podman`
-1. With `podman-compose` and a valid `docker-compose.yml` configuration _(🟡 it may not be installed by default with podman)_
+### Step 2A - Creating and running a container via `podman`
 
-### Run the container with podman
-
-After running the container, the Teal application is available at `http://localhost:8787`.
+After running the container, the Pilot-4 application can be accessed in the browser at `http://localhost:8787`.
 
 ```bash
-$ podman machine init
-$ podman build . --tag experimental-fda-submission-4-podman
-$ podman pod create --publish 8787:8787 --name pilot-pod
-$ podman run -dt --pod pilot-pod experimental-fda-submission-4-podman:latest
+podman machine init
+podman build . --tag experimental-fda-submission-4-podman
+podman pod create --publish 8787:8787 --name pilot-pod
+podman run -dt --pod pilot-pod experimental-fda-submission-4-podman:latest
 ```
 
-### Run the container with podman-compose
+### Step 2B - Run the container with `podman-compose`
 
-After running the container, the Teal application is available at `http://localhost:8787`.
+After running the container, the Pilot-4 application can be accessed in the browser at `http://localhost:8787`.
 
 ```bash
-$ podman-compose up -d --pull
+podman-compose up -d --pull
 ```
 
-### Using GitHub Container Registry
+### Appendix
+
+#### Using GitHub Container Registry
 
 The user can use a different container registry from the default `docker.io` by changing the `BUILD ARGS` of the docker image.
 It needs to change the `IMAGE_REGISTRY=ghcr.io` and `IMAGE_ORG=rocker-org` to appropriate values.
@@ -50,7 +120,7 @@ The organization also needs to change as it has different usernames in `docker.i
 A preliminary step to login to GitHub registry is required, you can use your own GitHub username and password, or your personal access token (`PAT`).
 
 ```bash
-$ podman login ghcr.io --username <your-username-here>
+podman login ghcr.io --username <your-username-here>
 
 # or if you already a personal access token
 echo $PAT | podman login ghcr.io --username <your-username-here> --password-stdin
@@ -65,7 +135,7 @@ After login, to change the registry to GitHub you can use one of the methods bel
 1\. To build the image in the command line by running:
 
 ```bash
-$ podman build . --build-arg IMAGE_REGISTRY=ghcr.io --build-arg IMAGE_ORG=rocker-org --tag experimental-fda-submission-4-podman
+podman build . --build-arg IMAGE_REGISTRY=ghcr.io --build-arg IMAGE_ORG=rocker-org --tag experimental-fda-submission-4-podman
 ```
 
 2\. Edit the `Dockerfile` file by changing the following ARGS:
@@ -77,7 +147,7 @@ ARG IMAGE_ORG=rocker-org
 # ...
 
 # build the image by running:
-# $ podman build . --tag experimental-fda-submission-4-podman
+# podman build . --tag experimental-fda-submission-4-podman
 ```
 
 3\. Edit the `docker-compose.yml` by changing the `service.pilot-4-podman.build.args`:
@@ -95,7 +165,7 @@ ARG IMAGE_ORG=rocker-org
 # ...
 
 # build the image using podman-compose by running:
-# $ podman-compose build --pull pilot-4-podman
+# podman-compose build --pull pilot-4-podman
 ```
 
 ## Screenshot of the Pilot running

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ ARG IMAGE_ORG=rocker-org
 
 ℹ️ note: This can be done by changing the existing example in `docker-compose.yml` or creating a new service with the different registry.
 
-```
+```dockerfile
 # edit the lines below
 # ...
   build:

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -1,0 +1,72 @@
+## Installation and Requirements
+
+### Windows
+
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/Windows)
+2. Install [WSL 2 from the Microsoft Store](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R)
+3. Install python and pip if not already present. Then install the `podman-compose` package using the following command:
+
+   ```
+   pip install podman-compose
+   ```
+
+4. Open the `Control panel` -> Open `Turn Windows feature on or off` -> Make sure that the `Windows Hypervisor Platform` is checked. Restart the computer if you just checked it.
+5. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+### Ubuntu
+
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/Linux)
+
+2. Install `podman-compose` using apt or PyPl
+   ```
+   sudo apt install qemu-system podman podman-compose -y
+   ```
+   or
+   ```
+   pip install podman-compose
+   ```
+3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+### MacOS
+
+1. Install [Podman Desktop](https://podman-desktop.io/downloads/MacOS)
+
+   Alternatively, you can install it using brew
+
+   ```
+   brew install podman
+   ```
+
+2. Install `podman-compose` using homebrew or PyPl
+   ```
+   brew install podman-compose
+   ```
+   or
+   ```
+   pip install podman-compose
+   ```
+3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
+
+   Alternatively, this can be done by running the following command
+
+   ```
+   podman machine init
+   ```
+
+#### Private images
+
+If you plan to use a private image you need to configure registries so Podman has access to pulling them. You can do this in the `Settings` -> `Registries`
+
+However, this repository does not use any private image so this step is not required.

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -52,7 +52,7 @@
 
    Alternatively, you can install it using brew
 
-   ```
+   ```bash
    brew install podman
    ```
 

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -18,7 +18,7 @@
 
    Alternatively, this can be done by running the following command
 
-   ```
+   ```bash
    podman machine init
    ```
 
@@ -34,7 +34,7 @@
 
    or
 
-   ```
+   ```bash
    pip install podman-compose
    ```
 
@@ -42,7 +42,7 @@
 
    Alternatively, this can be done by running the following command
 
-   ```
+   ```bash
    podman machine init
    ```
 
@@ -58,13 +58,13 @@
 
 2. Install `podman-compose` using homebrew or PyPl
 
-   ```
+   ```bash
    brew install podman-compose
    ```
 
    or
 
-   ```
+   ```bash
    pip install podman-compose
    ```
 
@@ -72,7 +72,7 @@
 
    Alternatively, this can be done by running the following command
 
-   ```
+   ```bash
    podman machine init
    ```
 

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -3,7 +3,9 @@
 ### Windows
 
 1. Install [Podman Desktop](https://podman-desktop.io/downloads/Windows)
+
 2. Install [WSL 2 from the Microsoft Store](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R)
+
 3. Install python and pip if not already present. Then install the `podman-compose` package using the following command:
 
    ```bash
@@ -11,6 +13,7 @@
    ```
 
 4. Open the `Control panel` -> Open `Turn Windows feature on or off` -> Make sure that the `Windows Hypervisor Platform` is checked. Restart the computer if you just checked it.
+
 5. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
 
    Alternatively, this can be done by running the following command
@@ -24,13 +27,17 @@
 1. Install [Podman Desktop](https://podman-desktop.io/downloads/Linux)
 
 2. Install `podman-compose` using apt or PyPl
+
    ```
    sudo apt install qemu-system podman podman-compose -y
    ```
+
    or
+
    ```
    pip install podman-compose
    ```
+
 3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
 
    Alternatively, this can be done by running the following command
@@ -50,13 +57,17 @@
    ```
 
 2. Install `podman-compose` using homebrew or PyPl
+
    ```
    brew install podman-compose
    ```
+
    or
+
    ```
    pip install podman-compose
    ```
+
 3. Create a new Podman machine in the Podman Desktop by going to the `Settings` -> `Resources` -> `Create new Podman machine`
 
    Alternatively, this can be done by running the following command

--- a/installation_guide.md
+++ b/installation_guide.md
@@ -6,7 +6,7 @@
 2. Install [WSL 2 from the Microsoft Store](https://apps.microsoft.com/store/detail/windows-subsystem-for-linux/9P9TQF7MRM4R)
 3. Install python and pip if not already present. Then install the `podman-compose` package using the following command:
 
-   ```
+   ```bash
    pip install podman-compose
    ```
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Closes:
- #11 

## Changes description

- Adds Podman installation steps for different OS in the readme.

