### PR TITLE
Add --name parameter to podman create

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After running the container, the Teal application is available at `http://localh
 ```bash
 $ podman machine init
 $ podman build . --tag experimental-fda-submission-4-podman
-$ podman pod create --publish 8787:8787 pilot-pod
+$ podman pod create --publish 8787:8787 --name pilot-pod
 $ podman run -dt --pod pilot-pod experimental-fda-submission-4-podman:latest
 ```
 


### PR DESCRIPTION
## Changes description

This PR adds the `--name` parameter in the command to create the pod via podman. At least in my version of podman `3.4.4`, you need to specify the `--name` option before the `pilot-pod` string identifier, as follows:

```
podman pod create --publish 8787:8787 --name pilot_pod
```

Once I made that small change, I was able to run the remaining commands to get the application running on my local system.