### PR TITLE
Making the container rootless and adding document on mounting volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,12 @@ RUN apt-get update --quiet \
    && apt-get clean --quiet \
    && rm -rf /var/lib/apt/lists/*
 
+RUN useradd -m shiny
+
+USER shiny
+
 ARG LOCAL_DIR=./submissions-pilot2
-ARG APP_DIR=/usr/local/src/submissions-pilot2
+ARG APP_DIR=/home/shiny/submissions-pilot2
 
 COPY $LOCAL_DIR $APP_DIR
 

--- a/development_guide.md
+++ b/development_guide.md
@@ -8,7 +8,7 @@ One use case for this is that you have a container with all the required code to
 
 In this case, let's assume that we want to change the four xpt files inside the `datasets/adam`: `adadas.xpt`, `adlbc.xpt`, `adsl.xpr`, and `adtte.xpt`. We can do this by running this command.
 
-```
+```bash
 podman run -dt --pod pilot-pod -v ./submissions-pilot2/datasets:/home/shiny/submissions-pilot2/datasets experimental-fda-submission-4-podman:latest
 ```
 

--- a/development_guide.md
+++ b/development_guide.md
@@ -1,0 +1,15 @@
+# Development Guide
+
+## Mounting volumes
+
+If you wish to mount files from the host machine to the Docker containers you can do so with the help of volumes.
+
+One use case for this is that you have a container with all the required code to run the Shiny app but you would like to run the Shiny app for different datasets and you don't want to wait around for the new Docker image to build with your new dataset. By mounting the new datasets you can simply source your new dataset to the containers.
+
+In this case, let's assume that we want to change the four xpt files inside the `datasets/adam`: `adadas.xpt`, `adlbc.xpt`, `adsl.xpr`, and `adtte.xpt`. We can do this by running this command.
+
+```
+podman run -dt --pod pilot-pod -v ./submissions-pilot2/datasets:/home/shiny/submissions-pilot2/datasets experimental-fda-submission-4-podman:latest
+```
+
+You can change the `./submissions-pilot2/datasets` with any location to mount that particular directory. The syntax of the volume mount is `PATH_IN_THE_HOST_MACHINE:PATH_IN_CONTAINER`


### PR DESCRIPTION
Closes:

- #7 
- #6 

Changes:

- In the Dockerfile installs the system packages as root and creates a new user called `shiny` and performers future steps.
- Adds documentation on creating volumes and changing the datasets without rebuilding the image