### PR TITLE
Adds CI that builds images in amd64 and arm64

### DIFF
--- a/.github/workflows/image_renv_cache.yml
+++ b/.github/workflows/image_renv_cache.yml
@@ -1,32 +1,22 @@
-name: Build images
+name: Build images 📸
 
 on:
   push:
 
 env:
   RENV_PATHS_ROOT: renv_cache
-
 jobs:
-  # ######################################################################
-  #
-  #    _____       _                                      _   __ _  _
-  #   / ____|     | |                                    | | / /| || |
-  #  | |  __  ___ | | ___ _ __ ___     __ _ _ __ ___   __| |/ /_| || |_
-  #  | | |_ |/ _ \| |/ _ \ '_ ` _ \   / _` | '_ ` _ \ / _` | '_ \__   _|
-  #  | |__| | (_) | |  __/ | | | | | | (_| | | | | | | (_| | (_) | | |
-  #   \_____|\___/|_|\___|_| |_| |_|  \__,_|_| |_| |_|\__,_|\___/  |_|
-  #
-  #
-  #
-  #  Golem amd64
-  # #####################################################################
-  pilot2-image-amd64:
+  pilot2-golem-image:
+    name: Golem check 🗿
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     env:
       R_VERSION: 4.2.0
       IMAGE_NAME: pilot4-renv-cache
       RENV_PATHS_LOCKFILE: submissions-pilot2/renv.lock
-      PLATFORM: linux/amd64
+      PLATFORM: ${{ matrix.platform }}
     steps:
       - name: System deppendencies
         run: |
@@ -36,7 +26,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
       - name: Cache renv_cache
         id: cache-renv
         uses: actions/cache@v3
@@ -56,133 +45,17 @@ jobs:
             ./Dockerfile
           extra-args: |
             --volume ${{ github.workspace }}/renv_cache:/renv_cache
-  # #####################################################################
-  #
-  #    _____       _                                         __ _  _
-  #   / ____|     | |                                       / /| || |
-  #  | |  __  ___ | | ___ _ __ ___     __ _ _ __ _ __ ___  / /_| || |_
-  #  | | |_ |/ _ \| |/ _ \ '_ ` _ \   / _` | '__| '_ ` _ \| '_ \__   _|
-  #  | |__| | (_) | |  __/ | | | | | | (_| | |  | | | | | | (_) | | |
-  #   \_____|\___/|_|\___|_| |_| |_|  \__,_|_|  |_| |_| |_|\___/  |_|
-  #
-  #
-  #
-  #  Golem arm64
-  # ####################################################################
-  pilot2-image-arm64:
+  pilot2-rhino-image:
+    name: Rhino check 🦏
     runs-on: ubuntu-latest
-    env:
-      R_VERSION: 4.2.0
-      IMAGE_NAME: pilot4-renv-cache
-      RENV_PATHS_LOCKFILE: submissions-pilot2/renv.lock
-      PLATFORM: linux/arm64
-    steps:
-      - name: System deppendencies
-        run: |
-          sudo apt update --quiet
-          sudo apt install -y --quiet qemu-user-static
-
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Cache renv_cache
-        id: cache-renv
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
-          restore-keys: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}
-
-      - name: Build
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.IMAGE_NAME }}
-          context: ./
-          tags: v1
-          platforms: ${{ env.PLATFORM }}
-          containerfiles: |
-            ./Dockerfile
-          extra-args: |
-            --volume ${{ github.workspace }}/renv_cache:/renv_cache
-
-  # ###################################################################
-  #
-  #   _____  _     _                                   _   __ _  _
-  #  |  __ \| |   (_)                                 | | / /| || |
-  #  | |__) | |__  _ _ __   ___     __ _ _ __ ___   __| |/ /_| || |_
-  #  |  _  /| '_ \| | '_ \ / _ \   / _` | '_ ` _ \ / _` | '_ \__   _|
-  #  | | \ \| | | | | | | | (_) | | (_| | | | | | | (_| | (_) | | |
-  #  |_|  \_\_| |_|_|_| |_|\___/   \__,_|_| |_| |_|\__,_|\___/  |_|
-  #
-  #
-  #
-  #  Rhino amd64
-  # ##################################################################
-  pilot2-rhino-image-amd64:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     env:
       R_VERSION: 4.3.0
       IMAGE_NAME: pilot4-rhino-renv-cache
       RENV_PATHS_LOCKFILE: rhino/pilot2-modified/renv.lock
-      PLATFORM: linux/amd64
-    steps:
-      - name: System deppendencies
-        run: |
-          sudo apt update -q
-          sudo apt install -y --quiet \
-            qemu-user-static
-
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Cache renv_cache
-        id: cache-renv
-        uses: actions/cache@v3
-        with:
-          path: renv_cache
-          key: ${{ runner.os }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
-          restore-keys: ${{ runner.os }}-${{ env.R_VERSION }}
-
-      - name: Build
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ${{ env.IMAGE_NAME }}
-          context: ./
-          tags: v1
-          platforms: ${{ env.PLATFORM }}
-          containerfiles: |
-            ./Dockerfile
-          build-args: |
-            R_VERSION=${{ env.R_VERSION }}
-            IMAGE_ORG=rocker
-            IMAGE_REGISTRY=docker.io
-            LOCAL_DIR=./rhino/pilot2-modified
-            R_SCRIPT=./rhino/entrypoint.R
-          extra-args: |
-            --volume ${{ github.workspace }}/renv_cache:/renv_cache
-
-  # ##################################################################
-  #
-  #   _____  _     _                                      __ _  _
-  #  |  __ \| |   (_)                                    / /| || |
-  #  | |__) | |__  _ _ __   ___     __ _ _ __ _ __ ___  / /_| || |_
-  #  |  _  /| '_ \| | '_ \ / _ \   / _` | '__| '_ ` _ \| '_ \__   _|
-  #  | | \ \| | | | | | | | (_) | | (_| | |  | | | | | | (_) | | |
-  #  |_|  \_\_| |_|_|_| |_|\___/   \__,_|_|  |_| |_| |_|\___/  |_|
-  #
-  #
-  #
-  #  Rhino arm64
-  # #################################################################
-  pilot2-rhino-image-arm64:
-    runs-on: ubuntu-latest
-    env:
-      R_VERSION: 4.3.0
-      IMAGE_NAME: pilot4-rhino-renv-cache
-      RENV_PATHS_LOCKFILE: rhino/pilot2-modified/renv.lock
-      PLATFORM: linux/arm64
+      PLATFORM: ${{ matrix.platform }}
     steps:
       - name: System deppendencies
         run: |

--- a/.github/workflows/image_renv_cache.yml
+++ b/.github/workflows/image_renv_cache.yml
@@ -1,0 +1,221 @@
+name: Build images
+
+on:
+  push:
+
+env:
+  RENV_PATHS_ROOT: renv_cache
+
+jobs:
+  # ######################################################################
+  #
+  #    _____       _                                      _   __ _  _
+  #   / ____|     | |                                    | | / /| || |
+  #  | |  __  ___ | | ___ _ __ ___     __ _ _ __ ___   __| |/ /_| || |_
+  #  | | |_ |/ _ \| |/ _ \ '_ ` _ \   / _` | '_ ` _ \ / _` | '_ \__   _|
+  #  | |__| | (_) | |  __/ | | | | | | (_| | | | | | | (_| | (_) | | |
+  #   \_____|\___/|_|\___|_| |_| |_|  \__,_|_| |_| |_|\__,_|\___/  |_|
+  #
+  #
+  #
+  #  Golem amd64
+  # #####################################################################
+  pilot2-image-amd64:
+    runs-on: ubuntu-latest
+    env:
+      R_VERSION: 4.2.0
+      IMAGE_NAME: pilot4-renv-cache
+      RENV_PATHS_LOCKFILE: submissions-pilot2/renv.lock
+      PLATFORM: linux/amd64
+    steps:
+      - name: System deppendencies
+        run: |
+          sudo apt update --quiet
+          sudo apt install -y --quiet qemu-user-static
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Cache renv_cache
+        id: cache-renv
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.RENV_PATHS_ROOT }}
+          key: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
+          restore-keys: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}
+
+      - name: Build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          context: ./
+          tags: v1
+          platforms: ${{ env.PLATFORM }}
+          containerfiles: |
+            ./Dockerfile
+          extra-args: |
+            --volume ${{ github.workspace }}/renv_cache:/renv_cache
+  # #####################################################################
+  #
+  #    _____       _                                         __ _  _
+  #   / ____|     | |                                       / /| || |
+  #  | |  __  ___ | | ___ _ __ ___     __ _ _ __ _ __ ___  / /_| || |_
+  #  | | |_ |/ _ \| |/ _ \ '_ ` _ \   / _` | '__| '_ ` _ \| '_ \__   _|
+  #  | |__| | (_) | |  __/ | | | | | | (_| | |  | | | | | | (_) | | |
+  #   \_____|\___/|_|\___|_| |_| |_|  \__,_|_|  |_| |_| |_|\___/  |_|
+  #
+  #
+  #
+  #  Golem arm64
+  # ####################################################################
+  pilot2-image-arm64:
+    runs-on: ubuntu-latest
+    env:
+      R_VERSION: 4.2.0
+      IMAGE_NAME: pilot4-renv-cache
+      RENV_PATHS_LOCKFILE: submissions-pilot2/renv.lock
+      PLATFORM: linux/arm64
+    steps:
+      - name: System deppendencies
+        run: |
+          sudo apt update --quiet
+          sudo apt install -y --quiet qemu-user-static
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Cache renv_cache
+        id: cache-renv
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.RENV_PATHS_ROOT }}
+          key: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
+          restore-keys: ${{ runner.os }}-${{ env.PLATFORM }}-${{ env.R_VERSION }}
+
+      - name: Build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          context: ./
+          tags: v1
+          platforms: ${{ env.PLATFORM }}
+          containerfiles: |
+            ./Dockerfile
+          extra-args: |
+            --volume ${{ github.workspace }}/renv_cache:/renv_cache
+
+  # ###################################################################
+  #
+  #   _____  _     _                                   _   __ _  _
+  #  |  __ \| |   (_)                                 | | / /| || |
+  #  | |__) | |__  _ _ __   ___     __ _ _ __ ___   __| |/ /_| || |_
+  #  |  _  /| '_ \| | '_ \ / _ \   / _` | '_ ` _ \ / _` | '_ \__   _|
+  #  | | \ \| | | | | | | | (_) | | (_| | | | | | | (_| | (_) | | |
+  #  |_|  \_\_| |_|_|_| |_|\___/   \__,_|_| |_| |_|\__,_|\___/  |_|
+  #
+  #
+  #
+  #  Rhino amd64
+  # ##################################################################
+  pilot2-rhino-image-amd64:
+    runs-on: ubuntu-latest
+    env:
+      R_VERSION: 4.3.0
+      IMAGE_NAME: pilot4-rhino-renv-cache
+      RENV_PATHS_LOCKFILE: rhino/pilot2-modified/renv.lock
+      PLATFORM: linux/amd64
+    steps:
+      - name: System deppendencies
+        run: |
+          sudo apt update -q
+          sudo apt install -y --quiet \
+            qemu-user-static
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Cache renv_cache
+        id: cache-renv
+        uses: actions/cache@v3
+        with:
+          path: renv_cache
+          key: ${{ runner.os }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
+          restore-keys: ${{ runner.os }}-${{ env.R_VERSION }}
+
+      - name: Build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          context: ./
+          tags: v1
+          platforms: ${{ env.PLATFORM }}
+          containerfiles: |
+            ./Dockerfile
+          build-args: |
+            R_VERSION=${{ env.R_VERSION }}
+            IMAGE_ORG=rocker
+            IMAGE_REGISTRY=docker.io
+            LOCAL_DIR=./rhino/pilot2-modified
+            R_SCRIPT=./rhino/entrypoint.R
+          extra-args: |
+            --volume ${{ github.workspace }}/renv_cache:/renv_cache
+
+  # ##################################################################
+  #
+  #   _____  _     _                                      __ _  _
+  #  |  __ \| |   (_)                                    / /| || |
+  #  | |__) | |__  _ _ __   ___     __ _ _ __ _ __ ___  / /_| || |_
+  #  |  _  /| '_ \| | '_ \ / _ \   / _` | '__| '_ ` _ \| '_ \__   _|
+  #  | | \ \| | | | | | | | (_) | | (_| | |  | | | | | | (_) | | |
+  #  |_|  \_\_| |_|_|_| |_|\___/   \__,_|_|  |_| |_| |_|\___/  |_|
+  #
+  #
+  #
+  #  Rhino arm64
+  # #################################################################
+  pilot2-rhino-image-arm64:
+    runs-on: ubuntu-latest
+    env:
+      R_VERSION: 4.3.0
+      IMAGE_NAME: pilot4-rhino-renv-cache
+      RENV_PATHS_LOCKFILE: rhino/pilot2-modified/renv.lock
+      PLATFORM: linux/arm64
+    steps:
+      - name: System deppendencies
+        run: |
+          sudo apt update -q
+          sudo apt install -y --quiet \
+            qemu-user-static
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Cache renv_cache
+        id: cache-renv
+        uses: actions/cache@v3
+        with:
+          path: renv_cache
+          key: ${{ runner.os }}-${{ env.R_VERSION }}-${{ hashFiles('$RENV_PATHS_LOCKFILE') }}
+          restore-keys: ${{ runner.os }}-${{ env.R_VERSION }}
+
+      - name: Build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          context: ./
+          tags: v1
+          platforms: ${{ env.PLATFORM }}
+          containerfiles: |
+            ./Dockerfile
+          build-args: |
+            R_VERSION=${{ env.R_VERSION }}
+            IMAGE_ORG=rocker
+            IMAGE_REGISTRY=docker.io
+            LOCAL_DIR=./rhino/pilot2-modified
+            R_SCRIPT=./rhino/entrypoint.R
+          extra-args: |
+            --volume ${{ github.workspace }}/renv_cache:/renv_cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submissions-pilot2"]
 	path = submissions-pilot2
-	url = https://github.com/RConsortium/submissions-pilot2
+	url = https://github.com/Appsilon/submissions-pilot2
 [submodule "rhino/pilot2-modified"]
 	path = rhino/pilot2-modified
 	url = https://github.com/Appsilon/rhino-fda-pilot


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issues:

- Closes #14 

## Open question

* [ ] Should we remove Pilot2 (Golem) arm64 from build until problem with packages is resolved upstream?

## Changes description

* Adds CI that builds
    * amd64
    * arm64
* Uses `actions/cache` to leverage local cache and speed up the CI
    * First run takes a lot of time, following are fast
